### PR TITLE
fix: add dill and greenlet package dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ classifiers = [
 dependencies = [
     "bytecode @ git+https://github.com/ZwFink/bytecode.git",
     "numpy",
+    "dill",
+    "greenlet",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -244,5 +244,10 @@ setup(
     },
     zip_safe=False,
     python_requires=">=3.13",
-    install_requires=["bytecode @ git+https://github.com/ZwFink/bytecode.git", "numpy"],
+    install_requires=[
+        "bytecode @ git+https://github.com/ZwFink/bytecode.git",
+        "numpy",
+        "dill",
+        "greenlet",
+    ],
 )


### PR DESCRIPTION
Add missing runtime dependencies to package metadata so standard installs pull required modules.

- Add dill and greenlet to project dependencies in pyproject.toml
- Add dill and greenlet to install_requires in setup.py
- Align install metadata with requirements.txt to prevent import-time missing dependency errors
